### PR TITLE
Issues/protocol/18 nested inputs in docs

### DIFF
--- a/src/main/coffeescript/view/OperationView.coffee
+++ b/src/main/coffeescript/view/OperationView.coffee
@@ -84,6 +84,21 @@ class OperationView extends Backbone.View
     responseContentTypeView = new ResponseContentTypeView({model: contentTypeModel})
     $('.response-content-type', $(@el)).append responseContentTypeView.render().el
 
+    # Mark parameters as child (indented)
+    suffix_pattern = /\[[^\[]*\]$/
+    parents = []
+    for param in @model.parameters
+      if suffix_pattern.test(param.name)
+        parents.push param.name.replace(suffix_pattern, '')
+        level = param.name.match(/\[[^\[]*\]/g).length
+        param.level = level
+
+    # Mark parameters as parent (no input)
+    for param in @model.parameters
+      if parents.indexOf(param.name) >= 0
+        param.parent = true
+
+
     # Render each parameter
     @addParameter param, contentTypeModel.consumes for param in @model.parameters
 

--- a/src/main/coffeescript/view/OperationView.coffee
+++ b/src/main/coffeescript/view/OperationView.coffee
@@ -85,19 +85,20 @@ class OperationView extends Backbone.View
     $('.response-content-type', $(@el)).append responseContentTypeView.render().el
 
     # Mark parameters as child (indented)
+    paramIndex = @model.parameters.reduce(((index, param) -> 
+      index[param.name] = param
+      index
+    ), {})
     suffix_pattern = /\[[^\[]*\]$/
     parents = []
     for param in @model.parameters
       if suffix_pattern.test(param.name)
-        parents.push param.name.replace(suffix_pattern, '')
-        level = param.name.match(/\[[^\[]*\]/g).length
-        param.level = level
+        parent_name = param.name.replace(suffix_pattern, '')
+        parent = paramIndex[parent_name]
 
-    # Mark parameters as parent (no input)
-    for param in @model.parameters
-      if parents.indexOf(param.name) >= 0
-        param.parent = true
-
+        parent.isParent = true
+        param.parent = parent
+        param.level = param.name.match(/\[[^\[]*\]/g).length
 
     # Render each parameter
     @addParameter param, contentTypeModel.consumes for param in @model.parameters

--- a/src/main/coffeescript/view/ParameterView.coffee
+++ b/src/main/coffeescript/view/ParameterView.coffee
@@ -13,6 +13,7 @@ class ParameterView extends Backbone.View
     @model.isFile = true if type.toLowerCase() == 'file'
 
     @model.showInput = !@model.parent?
+    @model.indent = "indent-#{@model.level}"
 
     template = @template()
     $(@el).html(template(@model))

--- a/src/main/coffeescript/view/ParameterView.coffee
+++ b/src/main/coffeescript/view/ParameterView.coffee
@@ -12,6 +12,8 @@ class ParameterView extends Backbone.View
     @model.isBody = true if @model.paramType == 'body'
     @model.isFile = true if type.toLowerCase() == 'file'
 
+    @model.showInput = !@model.parent?
+
     template = @template()
     $(@el).html(template(@model))
 

--- a/src/main/coffeescript/view/ParameterView.coffee
+++ b/src/main/coffeescript/view/ParameterView.coffee
@@ -12,8 +12,14 @@ class ParameterView extends Backbone.View
     @model.isBody = true if @model.paramType == 'body'
     @model.isFile = true if type.toLowerCase() == 'file'
 
-    @model.showInput = !@model.parent?
+    @model.showInput = !@model.isParent?
     @model.indent = "indent-#{@model.level}"
+
+    @model.reallyRequired = @model.required
+    parent = @model.parent
+    while parent? && @model.reallyRequired
+      @model.reallyRequired = false unless parent.required
+      parent = parent.parent
 
     template = @template()
     $(@el).html(template(@model))
@@ -60,7 +66,9 @@ class ParameterView extends Backbone.View
         else
           Handlebars.templates.param_readonly
       else
-        if @model.required
+        if @model.reallyRequired
           Handlebars.templates.param_required
+        else if @model.required
+          Handlebars.templates.param_child_required
         else
           Handlebars.templates.param

--- a/src/main/html/css/screen.css
+++ b/src/main/html/css/screen.css
@@ -412,6 +412,18 @@
 .swagger-section .swagger-ui-wrap .required {
   font-weight: bold;
 }
+.swagger-section .swagger-ui-wrap .indent-1 {
+  padding-left: 15px;
+}
+.swagger-section .swagger-ui-wrap .indent-2 {
+  padding-left: 30px;
+}
+.swagger-section .swagger-ui-wrap .indent-3 {
+  padding-left: 45px;
+}
+.swagger-section .swagger-ui-wrap .indent-4 {
+  padding-left: 60px;
+}
 .swagger-section .swagger-ui-wrap input.parameter {
   width: 300px;
   border: 1px solid #aaa;

--- a/src/main/less/specs.less
+++ b/src/main/less/specs.less
@@ -307,6 +307,14 @@
         font-weight: bold;
     }
 
+    .indent(@level) {
+      padding-left: 15px * @level;
+    }
+    .indent-1 { .indent(1); }
+    .indent-2 { .indent(2); }
+    .indent-3 { .indent(3); }
+    .indent-4 { .indent(4); }
+
     input.parameter {
         width: 300px;
         border: 1px solid #aaa;

--- a/src/main/template/param.handlebars
+++ b/src/main/template/param.handlebars
@@ -1,35 +1,36 @@
 <td class='code'>{{name}}</td>
 <td>
-
-	{{#if isBody}}
-		{{#if isFile}}
-			<input type="file" name='{{name}}'/>
-			<div class="parameter-content-type" />
-		{{else}}
-			{{#if defaultValue}}
-				<textarea class='body-textarea' name='{{name}}'>{{defaultValue}}</textarea>
-			{{else}}
-				<textarea class='body-textarea' name='{{name}}'></textarea>
-				<br />
-				<div class="parameter-content-type" />
-			{{/if}}
-		{{/if}}
-	{{else}}
-		{{#if isFile}}
-			<input type="file" name='{{name}}'/>
-			<div class="parameter-content-type" />
-		{{else}}
-			{{#if defaultValue}}
-				<input class='parameter' minlength='0' name='{{name}}' placeholder='' type='text' value='{{defaultValue}}'/>
-			{{else}}
-				<input class='parameter' minlength='0' name='{{name}}' placeholder='' type='text' value=''/>
-			{{/if}}
-		{{/if}}
-	{{/if}}
+{{#if showInput}}
+  {{#if isBody}}
+    {{#if isFile}}
+      <input type="file" name='{{name}}'/>
+      <div class="parameter-content-type" />
+    {{else}}
+      {{#if defaultValue}}
+        <textarea class='body-textarea' name='{{name}}'>{{defaultValue}}</textarea>
+      {{else}}
+        <textarea class='body-textarea' name='{{name}}'></textarea>
+        <br />
+        <div class="parameter-content-type" />
+      {{/if}}
+    {{/if}}
+  {{else}}
+    {{#if isFile}}
+      <input type="file" name='{{name}}'/>
+      <div class="parameter-content-type" />
+    {{else}}
+      {{#if defaultValue}}
+        <input class='parameter' minlength='0' name='{{name}}' placeholder='' type='text' value='{{defaultValue}}'/>
+      {{else}}
+        <input class='parameter' minlength='0' name='{{name}}' placeholder='' type='text' value=''/>
+      {{/if}}
+    {{/if}}
+  {{/if}}
+{{/if}}
 
 </td>
 <td>{{{description}}}</td>
 <td>{{{paramType}}}</td>
 <td>
-	<span class="model-signature"></span>
+  <span class="model-signature"></span>
 </td>

--- a/src/main/template/param.handlebars
+++ b/src/main/template/param.handlebars
@@ -1,4 +1,4 @@
-<td class='code'>{{name}}</td>
+<td class='code {{indent}}'>{{name}}</td>
 <td>
 {{#if showInput}}
   {{#if isBody}}

--- a/src/main/template/param_child_required.handlebars
+++ b/src/main/template/param_child_required.handlebars
@@ -1,0 +1,34 @@
+<td class='code required {{indent}}'>{{name}}</td>
+<td>
+  {{#if showInput}}
+    {{#if isBody}}
+      {{#if isFile}}
+        <input type="file" name='{{name}}'/>
+      {{else}}
+        {{#if defaultValue}}
+          <textarea class='body-textarea' name='{{name}}'>{{defaultValue}}</textarea>
+        {{else}}
+          <textarea class='body-textarea' name='{{name}}'></textarea>
+          <br />
+          <div class="parameter-content-type" />
+        {{/if}}
+      {{/if}}
+    {{else}}
+      {{#if isFile}}
+        <input class='parameter' type='file' name='{{name}}'/>
+      {{else}}
+        {{#if defaultValue}}
+          <input class='parameter' minlength='1' name='{{name}}' type='text' value='{{defaultValue}}'/>
+        {{else}}
+          <input class='parameter' minlength='1' name='{{name}}' type='text' value=''/>
+        {{/if}}
+      {{/if}}
+    {{/if}}
+  {{/if}}
+</td>
+<td>
+  <strong>{{{description}}}</strong>
+</td>
+<td>{{{paramType}}}</td>
+<td><span class="model-signature"></span></td>
+

--- a/src/main/template/param_readonly.handlebars
+++ b/src/main/template/param_readonly.handlebars
@@ -1,14 +1,16 @@
 <td class='code'>{{name}}</td>
 <td>
-    {{#if isBody}}
-        <textarea class='body-textarea' readonly='readonly' name='{{name}}'>{{defaultValue}}</textarea>
+{{#if showInput}}
+  {{#if isBody}}
+    <textarea class='body-textarea' readonly='readonly' name='{{name}}'>{{defaultValue}}</textarea>
+  {{else}}
+    {{#if defaultValue}}
+      {{defaultValue}}
     {{else}}
-        {{#if defaultValue}}
-            {{defaultValue}}
-        {{else}}
-            (empty)
-        {{/if}}
+      (empty)
     {{/if}}
+  {{/if}}
+{{/if}}
 </td>
 <td>{{{description}}}</td>
 <td>{{{paramType}}}</td>

--- a/src/main/template/param_readonly.handlebars
+++ b/src/main/template/param_readonly.handlebars
@@ -1,4 +1,4 @@
-<td class='code'>{{name}}</td>
+<td class='code {{indent}}'>{{name}}</td>
 <td>
 {{#if showInput}}
   {{#if isBody}}

--- a/src/main/template/param_readonly_required.handlebars
+++ b/src/main/template/param_readonly_required.handlebars
@@ -1,14 +1,16 @@
 <td class='code required'>{{name}}</td>
 <td>
-    {{#if isBody}}
-        <textarea class='body-textarea'  readonly='readonly' placeholder='(required)' name='{{name}}'>{{defaultValue}}</textarea>
+{{#if showInput}}
+  {{#if isBody}}
+    <textarea class='body-textarea'  readonly='readonly' placeholder='(required)' name='{{name}}'>{{defaultValue}}</textarea>
+  {{else}}
+    {{#if defaultValue}}
+      {{defaultValue}}
     {{else}}
-        {{#if defaultValue}}
-            {{defaultValue}}
-        {{else}}
-            (empty)
-        {{/if}}
+      (empty)
     {{/if}}
+  {{/if}}
+{{/if}}
 </td>
 <td>{{{description}}}</td>
 <td>{{{paramType}}}</td>

--- a/src/main/template/param_readonly_required.handlebars
+++ b/src/main/template/param_readonly_required.handlebars
@@ -1,4 +1,4 @@
-<td class='code required'>{{name}}</td>
+<td class='code required {{indent}}'>{{name}}</td>
 <td>
 {{#if showInput}}
   {{#if isBody}}

--- a/src/main/template/param_required.handlebars
+++ b/src/main/template/param_required.handlebars
@@ -1,31 +1,33 @@
 <td class='code required'>{{name}}</td>
 <td>
-	{{#if isBody}}
-		{{#if isFile}}
-			<input type="file" name='{{name}}'/>
-		{{else}}
-			{{#if defaultValue}}
-				<textarea class='body-textarea' placeholder='(required)' name='{{name}}'>{{defaultValue}}</textarea>
-			{{else}}
-				<textarea class='body-textarea' placeholder='(required)' name='{{name}}'></textarea>
-				<br />
-				<div class="parameter-content-type" />
-			{{/if}}
-		{{/if}}
-	{{else}}
-		{{#if isFile}}
-			<input class='parameter' class='required' type='file' name='{{name}}'/>
-		{{else}}
-			{{#if defaultValue}}
-				<input class='parameter required' minlength='1' name='{{name}}' placeholder='(required)' type='text' value='{{defaultValue}}'/>
-			{{else}}
-				<input class='parameter required' minlength='1' name='{{name}}' placeholder='(required)' type='text' value=''/>
-			{{/if}}
-		{{/if}}
-	{{/if}}
+  {{#if showInput}}
+    {{#if isBody}}
+      {{#if isFile}}
+        <input type="file" name='{{name}}'/>
+      {{else}}
+        {{#if defaultValue}}
+          <textarea class='body-textarea' placeholder='(required)' name='{{name}}'>{{defaultValue}}</textarea>
+        {{else}}
+          <textarea class='body-textarea' placeholder='(required)' name='{{name}}'></textarea>
+          <br />
+          <div class="parameter-content-type" />
+        {{/if}}
+      {{/if}}
+    {{else}}
+      {{#if isFile}}
+        <input class='parameter' class='required' type='file' name='{{name}}'/>
+      {{else}}
+        {{#if defaultValue}}
+          <input class='parameter required' minlength='1' name='{{name}}' placeholder='(required)' type='text' value='{{defaultValue}}'/>
+        {{else}}
+          <input class='parameter required' minlength='1' name='{{name}}' placeholder='(required)' type='text' value=''/>
+        {{/if}}
+      {{/if}}
+    {{/if}}
+  {{/if}}
 </td>
 <td>
-	<strong>{{{description}}}</strong>
+  <strong>{{{description}}}</strong>
 </td>
 <td>{{{paramType}}}</td>
 <td><span class="model-signature"></span></td>

--- a/src/main/template/param_required.handlebars
+++ b/src/main/template/param_required.handlebars
@@ -1,4 +1,4 @@
-<td class='code required'>{{name}}</td>
+<td class='code required {{indent}}'>{{name}}</td>
 <td>
   {{#if showInput}}
     {{#if isBody}}


### PR DESCRIPTION
Now handles nested params:
- Nested params (children) are indented
- Parent params have no inputs
- Child params that are required which have a parent this is not, is still marked in bold, but is not required by swagger.
